### PR TITLE
Auto-assign to requestor

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ reviewerGroupsByLabels:
     - reviewer3
     - reviewer4
 
-minAmountOfReviewers: 2 # a minimum amount of reviewers to be added to PR
+autoAssignToRequestor: true # auto assign opened pull equest to request (false by default)
+minAmountOfReviewers: 2     # a minimum amount of reviewers to be added to PR
 
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 import { Application } from 'probot'
-import { handlePullRequestLabelChange } from './handler'
+import {
+  handlePullRequestLabelChange,
+  handlePullRequestOpened
+} from './handler'
 
 export = (app: Application): void => {
   app.on('pull_request.labeled', handlePullRequestLabelChange)
+  app.on('pull_request.opened', handlePullRequestOpened)
 }

--- a/src/voodoo.ts
+++ b/src/voodoo.ts
@@ -1,5 +1,6 @@
 export interface AppConfig {
   minAmountOfReviewers: number
+  autoAssignToRequestor: boolean
   reviewerGroupsByLabels: { [key: string]: string[] }
 }
 

--- a/test/voodoo.test.ts
+++ b/test/voodoo.test.ts
@@ -6,6 +6,7 @@ describe('Voodoo', () => {
   beforeEach(() => {
     config = {
       minAmountOfReviewers: 2,
+      autoAssignToRequestor: false,
       reviewerGroupsByLabels: {
         label1: [ 'reviewer1', 'reviewer2' ],
         label2: [ 'reviewer3']


### PR DESCRIPTION
When pull request is opened it will auto assign PR to the author. Disabled by default.

```yml
# .github/pr-review-voodoo.yml
#...

autoAssignToRequestor: true # auto assign opened pull equest to request (false by default)
```